### PR TITLE
Support injecting additional title links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 template_opt/*
+examples_opt/*

--- a/examples/extra-titles.html
+++ b/examples/extra-titles.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>FAKE PAGE TITLE</title>
+  <!-- include files -->
+  <script src='https://resources.library.nd.edu/frame/code.js' type='text/javascript'></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function(event) {
+      const titles = [
+        { title: 'Sublibrary Title', href: 'http://google.com'}
+      ]
+      documentReady([], titles);
+    });
+  </script>
+  <!-- end -->
+</head>
+<body>
+  <div>FAKE PAGE CONTENT</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <ol>
     <li><a href='./examples/basic.html'>Basic Example</a></li>
     <li><a href='./examples/extra-links.html'>Extra Links Example</a></li>
+    <li><a href='./examples/extra-titles.html'>Extra Titles Example</a></li>
 </ol>
 </body>
 </html>

--- a/mangle-and-deploy.sh
+++ b/mangle-and-deploy.sh
@@ -3,7 +3,7 @@ BUCKET=resources.library.nd.edu
 
 function doStuff {
   # mangle html
-  munch --css ./template --html ./template --html ./examples --ignore .nd,.body,.classList,.library,.readyState,.status,.head,.s3-website-us-east-1,.amazonaws,.com,.edu,.href,.title
+  munch --css ./template --html ./template --html ./examples --ignore .nd,.body,.classList,.library,.readyState,.status,.head,.s3-website-us-east-1,.amazonaws,.com,.edu,.href,.title,.b
   # upload to aws
   aws s3 sync ./template_opt s3://${BUCKET}/frame --exclude '.*' --exclude '*.md' --acl public-read --profile wseAdmin
   echo "Deployed to ${BUCKET}.s3-website-us-east-1.amazonaws.com/frame."

--- a/mangle-and-deploy.sh
+++ b/mangle-and-deploy.sh
@@ -3,7 +3,7 @@ BUCKET=resources.library.nd.edu
 
 function doStuff {
   # mangle html
-  munch --css ./template --html ./template --ignore .nd,.body,.classList,.library,.readyState,.status,.head
+  munch --css ./template --html ./template --html ./examples --ignore .nd,.body,.classList,.library,.readyState,.status,.head,.s3-website-us-east-1,.amazonaws,.com,.edu,.href,.title
   # upload to aws
   aws s3 sync ./template_opt s3://${BUCKET}/frame --exclude '.*' --exclude '*.md' --acl public-read --profile wseAdmin
   echo "Deployed to ${BUCKET}.s3-website-us-east-1.amazonaws.com/frame."

--- a/server.js
+++ b/server.js
@@ -40,6 +40,6 @@ http.createServer((request, response) => {
           response.end(content, 'utf-8')
         }
     })
-
+    response.setHeader('Access-Control-Allow-Origin', '*');
 }).listen(port);
 console.log(`Server running at http://${hostname}:${port}/`)

--- a/template/code.js
+++ b/template/code.js
@@ -1,13 +1,13 @@
 // Call the documentReady() function to use this code
-function documentReady (links) {
   var headerTemplate = 'https://resources.library.nd.edu/frame/header.html'
   var footerTemplate = 'https://resources.library.nd.edu/frame/footer.html'
   var headTemplate = 'https://resources.library.nd.edu/frame/head.html'
+function documentReady (links, titles) {
 
   var wrappedClass = 'hesburgh-wrapped'
   // Check to see if the body has not been wrapped yet. If it has, do nothing.
   if(!document.body.classList.contains(wrappedClass)) {
-    addHeader(headerTemplate, links)
+    addHeader(headerTemplate, links, titles)
     addFooter(footerTemplate)
     updateHead(headTemplate)
 
@@ -21,9 +21,14 @@ function displayLink(link) {
   return '<div class="menu-link"><a href=' + link.href + '>' + link.title + '</a></div>'
 }
 
+function displayTitle(title) {
+  return '<div class="subtitle"><a href=' + title.href + ' class="subtitle">' + title.title + '</a></div>'
+}
+
 // add the tempalte haeder to the page
-function addHeader (headerTemplate, links) {
-  var ADDITIONAL_LINKS = '{{{ADDITIONAL_LINKS}}}'
+function addHeader (headerTemplate, links, titles) {
+  var ADDITIONAL_LINKS_VARIABLE = '{{{ADDITIONAL_LINKS}}}'
+  var ADDITIONAL_TITLES_VARIABLE = '{{{ADDITIONAL_TITLES}}}'
 
   // Get the replacement template with an xhr request
   var xhr= new XMLHttpRequest()
@@ -43,7 +48,17 @@ function addHeader (headerTemplate, links) {
           return displayLink(link)
         })
       }
-      newContent = newContent.replace('{{{ADDITIONAL_LINKS}}}', additionalLinks.join(''))
+      newContent = newContent.replace(ADDITIONAL_LINKS_VARIABLE, additionalLinks.join(''))
+
+      // Check if there are any additional titles to include and insert them
+      let additionalTitles = []
+      if(titles) {
+         additionalTitles = titles.map(function(title) {
+          return displayTitle(title)
+        })
+      }
+      newContent = newContent.replace(ADDITIONAL_TITLES_VARIABLE, additionalTitles.join(''))
+
       document.body.insertAdjacentHTML('afterbegin', newContent)
     } catch (e) {
       console.log(e)

--- a/template/code.js
+++ b/template/code.js
@@ -22,7 +22,7 @@ function displayLink(link) {
 }
 
 function displayTitle(title) {
-  return '<div class="subtitle"><a href=' + title.href + ' class="subtitle">' + title.title + '</a></div>'
+  return '<div><a href=' + title.href + '>' + title.title + '</a></div>'
 }
 
 // add the tempalte haeder to the page

--- a/template/header.html
+++ b/template/header.html
@@ -2,7 +2,9 @@
   <div id="banner">
     <div class="container-fluid">
       <a href="https://library.nd.edu/" class="hlhome">Hesburgh <em>Libraries</em></a>
-      {{{ADDITIONAL_TITLES}}}
+      <div class="subtitle">
+        {{{ADDITIONAL_TITLES}}}
+      </div>
     </div>
   </div>
   <div class="nav-search">

--- a/template/header.html
+++ b/template/header.html
@@ -2,6 +2,7 @@
   <div id="banner">
     <div class="container-fluid">
       <a href="https://library.nd.edu/" class="hlhome">Hesburgh <em>Libraries</em></a>
+      {{{ADDITIONAL_TITLES}}}
     </div>
   </div>
   <div class="nav-search">

--- a/template/template.css
+++ b/template/template.css
@@ -63,6 +63,11 @@ a {
   color: #93601D;
 }
 
+a.subtitle {
+  color: #fff !important;
+  text-decoration: none !important;
+}
+
 a.hlhome {
   color: #fff !important;
   text-decoration: none !important;
@@ -482,13 +487,23 @@ body.gold-blue #header h4 a {
 #banner {
   clear: both;
   background: #082142 url('images/fade.png') top repeat-x;
-  height: 70px;
 }
 #banner .container-fluid {
   background-position: top right;
   background-repeat: no-repeat;
-  height: 100%;
 }
+#banner .subtitle {
+  display: inline-block;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-right: 20px;
+  padding-left: 20px;
+  font-size: 28px;
+  font-family: GPCMed, sans-serif;
+  text-transform: uppercase;
+}
+
 
 .hlhome {
   font-size: 38px;

--- a/template/template.css
+++ b/template/template.css
@@ -63,11 +63,6 @@ a {
   color: #93601D;
 }
 
-a.subtitle {
-  color: #fff !important;
-  text-decoration: none !important;
-}
-
 a.hlhome {
   color: #fff !important;
   text-decoration: none !important;
@@ -497,13 +492,17 @@ body.gold-blue #header h4 a {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
-  padding-right: 20px;
+  padding-right: 50px;
   padding-left: 20px;
   font-size: 28px;
   font-family: GPCMed, sans-serif;
   text-transform: uppercase;
 }
 
+.subtitle > div a {
+  color: #fff !important;
+  text-decoration: none !important;
+}
 
 .hlhome {
   font-size: 38px;
@@ -863,7 +862,7 @@ button a {
 }
 
 
-#content { 
+#content {
   /*margin-left: auto;
   margin-right: auto;
   max-width: 1200px;


### PR DESCRIPTION
- Added support for injecting additional titles
- Created a new subtitle class to css. Could probably use some work.
- Added cross origin support when running locally
- Added extra titles example 
- Fixed the mangle to exclude the .href and .title properties that are being passed into the documentReady function 
- Mangled/deployed an example of this to http://resources-dev.library.nd.edu.s3-website-us-east-1.amazonaws.com/frame/extra-titles.html
- Fixed an existing bug with the mangler incorrectly rewriting the reference to images/hours.b.png